### PR TITLE
Fix production crash on next assessments

### DIFF
--- a/refugee_manager/admin.py
+++ b/refugee_manager/admin.py
@@ -282,24 +282,20 @@ class CaseAdmin(CaseOrClientAdmin):
         return '%s: %s' % (len(individuals),
                            truncatechars(', '.join(i.name for i in individuals), 50))
 
-    def next_assessment(self, obj):
+    @staticmethod
+    def next_assessment(obj):
         ONEMONTH = timedelta(days=30)
         SIXMONTHS = timedelta(days=183)
         oas = obj.assessment
         count = oas.count()
         if not obj.active:
-            last = oas.latest()
-            if last.date < obj.end:
-                return obj.end
+            return None
         elif count == 0:
-            # Schedule 1mo from start
+            # 1 month from the case start
             return obj.start + ONEMONTH
         else:
-            # Every six months from start
-            last = oas.latest()
-            timepassed = last.date - obj.start
-            chunks = timepassed.days / SIXMONTHS.days  # GRR timedelta doesn't support division
-            return obj.start + (int(chunks) + 1) * SIXMONTHS
+            # Every six months from case start
+            return obj.start + (SIXMONTHS * count)
 
     list_display_links = list_display
     list_filter = ('active', VolunteerFilter, 'start', 'arrival', 'origin', 'language',

--- a/refugee_manager/tests.py
+++ b/refugee_manager/tests.py
@@ -1,16 +1,94 @@
-"""
-This file demonstrates writing tests using the unittest module. These will pass
-when you run "manage.py test".
-
-Replace this with more appropriate tests for your application.
-"""
+import datetime
 
 from django.test import TestCase
 
+from refugee_manager import admin
+from refugee_manager import models
 
-class SimpleTest(TestCase):
-    def test_basic_addition(self):
-        """
-        Tests that 1 + 1 always equals 2.
-        """
-        self.assertEqual(1 + 1, 2)
+
+class TestCaseAdmin(TestCase):
+
+    def test_next_assessment_active_1st(self):
+        """Verify the 1st assessment is 30 days from the case start."""
+        case = models.Case()
+        case.active = True
+        case.start = datetime.date(2008, 10, 15)
+        case.save()
+
+        actual = admin.CaseAdmin.next_assessment(case)
+
+        expected = datetime.date(2008, 11, 14)  # 30 days after the start
+        self.assertEqual(expected, actual)
+
+    def test_next_assessment_active_2nd(self):
+        """Verify the 2nd assessment is 183 days from the case start"""
+        case = models.Case()
+        case.active = True
+        case.start = datetime.date(2008, 10, 15)
+        case.save()
+
+        assessment = models.Assessment()
+        assessment.date = datetime.date(2008, 11, 25)
+        assessment.case = case
+        assessment.save()
+
+        actual = admin.CaseAdmin.next_assessment(case)
+
+        expected = datetime.date(2009, 4, 16)  # 183 days after the start
+        self.assertEqual(expected, actual)
+
+    def test_next_assessment_active_3nd_early(self):
+        """Verify an assessment can be done early."""
+        case = models.Case()
+        case.active = True
+        case.start = datetime.date(2008, 10, 15)
+        case.save()
+
+        assessment = models.Assessment()
+        assessment.date = datetime.date(2008, 11, 25)
+        assessment.case = case
+        assessment.save()
+
+        assessment = models.Assessment()
+        assessment.date = datetime.date(2009, 4, 1)  # due on 4/16
+        assessment.case = case
+        assessment.save()
+
+        actual = admin.CaseAdmin.next_assessment(case)
+
+        expected = datetime.date(2009, 10, 16)  # 183 * 2 days after the start
+        self.assertEqual(expected, actual)
+
+    def test_next_assessment_active_3nd_late(self):
+        """Verify an assessment can be done late."""
+        case = models.Case()
+        case.active = True
+        case.start = datetime.date(2008, 10, 15)
+        case.save()
+
+        assessment = models.Assessment()
+        assessment.date = datetime.date(2008, 11, 25)
+        assessment.case = case
+        assessment.save()
+
+        assessment = models.Assessment()
+        assessment.date = datetime.date(2009, 4, 30)  # due on 4/16
+        assessment.case = case
+        assessment.save()
+
+        actual = admin.CaseAdmin.next_assessment(case)
+
+        expected = datetime.date(2009, 10, 16)  # 183 * 2 days after the start
+        self.assertEqual(expected, actual)
+
+    def test_next_assessment_inactive(self):
+        """Verify there is no next assessment on an inactive case."""
+        case = models.Case()
+        case.active = False
+        case.start = datetime.date(2008, 10, 15)
+        case.save()
+
+        actual = admin.CaseAdmin.next_assessment(case)
+
+        expected = None
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
Fixes #101

The following changed:
- now, inactive cases never have a next assessment
- after the first assessment: `next assessment = case start + (6mo * assessment count)`
